### PR TITLE
fix layout of probe tree

### DIFF
--- a/src/controller/probes.ts
+++ b/src/controller/probes.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
-import { relative } from 'path';
 
 import { ProbeComment, createProbeComment, writeWilmaFile, deleteProbeComment, notifyProbeChange, ProbeCommentAction } from '../model/probe';
 import { updateDecorations } from '../view/decorations';
+import { relativePath } from '../utils';
 
 
 export function activateProbeComments(context: vscode.ExtensionContext): vscode.CommentController {
@@ -116,9 +116,7 @@ export function activateProbeComments(context: vscode.ExtensionContext): vscode.
         createProbeComment(
             reply.thread,
             reply.text,
-            vscode.workspace.workspaceFolders
-                ? relative(vscode.workspace.workspaceFolders[0].uri.fsPath, reply.thread.uri.fsPath)
-                : reply.thread.uri.fsPath
+            relativePath(reply.thread.uri)
         );
     }
 

--- a/src/model/probe.ts
+++ b/src/model/probe.ts
@@ -27,12 +27,16 @@ export class ProbeComment implements vscode.Comment {
         public parent: vscode.CommentThread,
         public contextValue?: string
     ) {
-        this.id = ++commentId; // TODO: Make this `${file}:${parent.range.start.line}`
+        this.id = ++commentId; // TODO: Make this `${file}:${linenum}`
         this.body = this.wrappedExpression();
     }
 
     public wrappedExpression(): vscode.MarkdownString {
         return new vscode.MarkdownString(`~~~py\n${this.expression}\n~~~`);
+    }
+
+    get linenum() {
+        return this.parent.range.start.line + 1;
     }
 }
 
@@ -103,7 +107,7 @@ export function writeWilmaFile() {
             new Map(
                 Array.from(
                     comments,
-                    ([_, probe]) => [`${probe.file}:${probe.parent.range.start.line + 1}`, probe.expression + "\n"]
+                    ([_, probe]) => [`${probe.file}:${probe.linenum}`, probe.expression + "\n"]
                 )
             )
         );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,9 @@
+
+import { relative } from "path";
+import * as vscode from "vscode";
+
+export function relativePath(uri: vscode.Uri) {
+    return vscode.workspace.workspaceFolders
+                ? relative(vscode.workspace.workspaceFolders[0].uri.fsPath, uri.fsPath)
+                : uri.fsPath
+}

--- a/src/view/decorations.ts
+++ b/src/view/decorations.ts
@@ -23,7 +23,7 @@ export function updateDecorations(editor: vscode.TextEditor | undefined) {
                 overviewRulerColor: 'orange',
                 overviewRulerLane: vscode.OverviewRulerLane.Left
             });
-            let line = probe.parent.range.start.line;
+            let line = probe.linenum - 1;
 
             editor.setDecorations(iconDecoration, [new vscode.Range(
                 editor.document.lineAt(line).range.start,


### PR DESCRIPTION
small improvement to the probe tree:
1. remove the full path from the file, now we show relative path
2. remove the file name from the probe name. 
3. order probes by line number
4. tooltip is now syntax highlighted 
